### PR TITLE
fix: add a condition to check whether the imagePullSecrets value is provided.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -179,10 +179,10 @@ resource "helm_release" "logs_agent" {
     }
   ]
 
-  set_list = [{
+  set_list = length(var.logs_agent_image_pull_secrets) > 0 ? [{
     name  = "image.imagePullSecrets"
     value = var.logs_agent_image_pull_secrets
-  }]
+  }] : []
 
   set_sensitive = [{
     name  = "secret.iamAPIKey"


### PR DESCRIPTION
### Description

* [Cloud automation for Logs Agent](https://cloud.ibm.com/catalog/7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3/architecture/deploy-arch-ibm-logs-agent-b3fb668c-6f9d-4db3-9073-9a677ccf4394-global?format=terraform&kind=terraform&version=7ff1fd12-9282-48d4-8b11-2f094dc3a255-global)

#### Issues seen

Unable to restart daemonset. On further debugging I see that a new variable called `logs_agent_image_pull_secrets` is introduced, its default value is `[]`. Due to this the logs agent DS Config looks as below:

```yaml
sai-madhav-koppara@dhcp-9-127-40-140 gc % oc get daemonset logs-agent -n ibm-observe -o yaml                                          
apiVersion: apps/v1
kind: DaemonSet
metadata:
  annotations:
    deprecated.daemonset.template.generation: "1"
    meta.helm.sh/release-name: logs-agent
    meta.helm.sh/release-namespace: ibm-observe
    version: 1.9.0
  creationTimestamp: "2026-08-07T07:33:09Z"
  generation: 1
  labels:
    app: logs-agent
    app.kubernetes.io/managed-by: Helm
    version: 1.9.0
  name: logs-agent
  namespace: ibm-observe
  resourceVersion: "7071306"
  uid: 8648c6fb-3f3a-483d-8feb-251fe61bdfdf
spec:
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: logs-agent
  template:
    metadata:
      annotations:
        checksum/config: e4c36ea63e64fb9c4fdaa8fe9cea27c35388b3fdf87c768d21ca8016761bf0e2
        openshift.io/required-scc: hostmount-logger-logs-agent
        prometheus.io/path: /api/v2/metrics/prometheus
        prometheus.io/port: "8081"
        prometheus.io/scrape: "true"
      creationTimestamp: null
      labels:
        app: logs-agent
        name: logs-agent
        version: 1.9.0
    spec:
      containers:
      - command:
        - /bin/sh
        - -c
        - |
          export KUBE_HOSTNAME=`cat /etc/kube-hostname`
          /fluent-bit/bin/fluent-bit --config=/fluent-bit/etc/fluent-bit.yaml
        env:
        - name: NODE_NAME
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: spec.nodeName
        - name: HOST_IP
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: status.hostIP
        - name: POD_NAME
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.name
        image: icr.io/ibm/observe/logs-router-agent:1.9.0@sha256:cd8366616039202736c7abd25386defeefcad4264bb1a1da6dca3bf82b088aa2
        imagePullPolicy: Always
        livenessProbe:
          failureThreshold: 3
          httpGet:
            path: /api/v1/health
            port: 8081
            scheme: HTTP
          initialDelaySeconds: 5
          periodSeconds: 20
          successThreshold: 1
          timeoutSeconds: 1
        name: fluent-bit
        readinessProbe:
          failureThreshold: 3
          httpGet:
            path: /api/v1/health
            port: 8081
            scheme: HTTP
          initialDelaySeconds: 10
          periodSeconds: 20
          successThreshold: 1
          timeoutSeconds: 1
        resources:
          limits:
            cpu: 500m
            memory: 3Gi
          requests:
            cpu: 100m
            memory: 1Gi
        securityContext:
          capabilities:
            add:
            - DAC_READ_SEARCH
          privileged: false
          runAsGroup: 10000
          runAsUser: 10000
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /var/run/secrets/tokens
          name: vault-token
        - mountPath: /var/log
          name: varlog
          readOnly: true
        - mountPath: /var/log/fluent-bit
          name: varlogfluentbit
        - mountPath: /fluent-bit/etc/
          name: logs-agent
        - mountPath: /etc/kube-hostname
          name: kubehostname
      dnsPolicy: ClusterFirst
      imagePullSecrets:
      - {}
      initContainers:
      - command:
        - scripts/make_db_dir.sh
        image: icr.io/ibm/observe/logs-router-agent-init:1.9.0@sha256:edd86fb2398d8daf7185fbeb9bfbae7051f19a8b2fb65109105fa22fb125f785
        imagePullPolicy: Always
        name: create-db-dir
        resources: {}
        securityContext:
          privileged: true
          runAsUser: 0
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /var/log
          name: varlog
      priorityClassName: logs-agent-ds-priority
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      serviceAccount: logs-agent
      serviceAccountName: logs-agent
      terminationGracePeriodSeconds: 10
      tolerations:
      - operator: Exists
      volumes:
      - name: vault-token
        projected:
          defaultMode: 420
          sources:
          - serviceAccountToken:
              audience: iam
              expirationSeconds: 7200
              path: vault-token
      - hostPath:
          path: /var/log
          type: ""
        name: varlog
      - hostPath:
          path: /var/log/fluent-bit
          type: ""
        name: varlogfluentbit
      - hostPath:
          path: /etc/hostname
          type: ""
        name: kubehostname
      - configMap:
          defaultMode: 420
          name: logs-agent
        name: logs-agent
  updateStrategy:
    rollingUpdate:
      maxSurge: 0
      maxUnavailable: 1
    type: RollingUpdate

```

where imagepull section looks as follows:

```yaml
      imagePullSecrets:
      - {}
```

When I try to restart I see the following issue:

```
sai-madhav-koppara@dhcp-9-127-40-140 gc % kubectl rollout restart daemonset logs-agent -n ibm-observe
error: daemonsets.apps "logs-agent" map: map[] does not contain declared merge key: name
```

<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
